### PR TITLE
Enclosed environment variables in quotes within deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,13 +53,13 @@ jobs:
           {
             "Variables": {
               "START_AS_HTTP": "false",
-              "API_PREFIX": ${{vars.API_PREFIX}},
-              "AIRTABLE_BASE_ID": ${{secrets.AIRTABLE_BASE_ID}},
-              "AIRTABLE_API_KEY": ${{secrets.AIRTABLE_API_KEY}},
-              "OPENAI_API_KEY": ${{secrets.OPENAI_API_KEY}},
-              "ADMIN_WEBFLOW_CMS_API_KEY": ${{secrets.ADMIN_WEBFLOW_CMS_API_KEY}},
-              "WEBFLOW_CMS_API_KEY": ${{secrets.WEBFLOW_CMS_API_KEY}},
-              "WEBFLOW_COLLECTION_ID": ${{secrets.WEBFLOW_COLLECTION_ID}}
+              "API_PREFIX": "${{vars.API_PREFIX}}",
+              "AIRTABLE_BASE_ID": "${{secrets.AIRTABLE_BASE_ID}}",
+              "AIRTABLE_API_KEY": "${{secrets.AIRTABLE_API_KEY}}",
+              "OPENAI_API_KEY": "${{secrets.OPENAI_API_KEY}}",
+              "ADMIN_WEBFLOW_CMS_API_KEY": "${{secrets.ADMIN_WEBFLOW_CMS_API_KEY}}",
+              "WEBFLOW_CMS_API_KEY": "${{secrets.WEBFLOW_CMS_API_KEY}}",
+              "WEBFLOW_COLLECTION_ID": "${{secrets.WEBFLOW_COLLECTION_ID}}"
             }
           }
           EOF


### PR DESCRIPTION
Fixes potential syntax issues by wrapping variables in double quotes for consistency and safety in `.github/workflows/deploy.yml`.